### PR TITLE
feat(recipes): показывать 3-й рецепт вместо кнопки + привёл страницу рецептов к стилю главной

### DIFF
--- a/project-tree.txt
+++ b/project-tree.txt
@@ -1,0 +1,72 @@
+.
+├── .env.local
+├── .github
+│   ├── pull_request_template.md
+│   └── workflows
+│       └── ci.yml
+├── .gitignore
+├── .vercel
+│   ├── project.json
+│   └── README.txt
+├── components.json
+├── eslint.config.mjs
+├── next-env.d.ts
+├── next.config.js
+├── next.config.ts
+├── package-lock.json
+├── package.json
+├── postcss.config.mjs
+├── project_tree_full.txt
+├── project-tree.txt
+├── public
+│   ├── file.svg
+│   ├── globe.svg
+│   ├── next.svg
+│   ├── robots.txt
+│   ├── vercel.svg
+│   └── window.svg
+├── README.md
+├── src
+│   ├── _middleware.ts
+│   ├── app
+│   │   ├── admin
+│   │   ├── api
+│   │   ├── confirm
+│   │   ├── favicon.ico
+│   │   ├── globals.css
+│   │   ├── layout.tsx
+│   │   ├── loading.tsx
+│   │   ├── page.tsx
+│   │   ├── recipes
+│   │   └── settings
+│   ├── components
+│   │   ├── confirm-products-panel.tsx
+│   │   ├── ConsentModal.tsx
+│   │   ├── FabSettings.tsx
+│   │   ├── InitAnalytics.tsx
+│   │   ├── manual-input.tsx
+│   │   ├── ProgressButton.tsx
+│   │   ├── recipe-card.tsx
+│   │   ├── settings
+│   │   ├── streamed-recipes-demo.tsx
+│   │   └── ui
+│   ├── lib
+│   │   ├── analytics-init.ts
+│   │   ├── analytics.ts
+│   │   ├── cache.ts
+│   │   ├── food-normalize.ts
+│   │   ├── normalize.ts
+│   │   ├── openai.ts
+│   │   ├── recipes-helpers.ts
+│   │   ├── recipes-sanitize.ts
+│   │   ├── supabase-server.ts
+│   │   ├── useStreamedRecipe.ts
+│   │   └── utils.ts
+│   ├── middleware.ts
+│   └── types
+│       ├── product.ts
+│       └── recipe.ts
+├── tree.txt
+└── tsconfig.json
+
+17 directories, 53 files

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,10 +1,12 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+/* Мягкий читаемый шрифт как на референсе */
+@import url("https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700;800&display=swap");
 
-/* вариант для тёмной темы (можно убрать, если не нужна) */
+/* вариант для тёмной темы */
 @custom-variant dark (&:is(.dark *));
 
-/* сопоставляем названия цветов tailwind с CSS-переменными */
+/* сопоставляем tailwind-цвета с CSS-переменными */
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -51,39 +53,74 @@
 
 /* светлая тема */
 :root {
-  --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --bg: #ffffff;
+  --fg: #0a0a0a;
+  --muted: #f5f5f5;
+  --muted-fg: #6b7280;  /* gray-500/600 */
+  --border: #e5e7eb;    /* gray-200 */
 }
+
+/* Нейтральные карточки без «персика» и градиентов */
+.glass-card,
+.glass {
+  background: #ffffff;
+  border: 1px solid var(--border);
+  box-shadow: 0 6px 20px rgba(0,0,0,0.06);
+}
+
+.glass-border { border-color: var(--border); }
+/* было тёплое свечение — сделаем нейтральное */
+.glass-glow {
+  box-shadow: 0 12px 40px rgba(0,0,0,.06) !important;
+  /* никаких оранжевых теней/радиальных градиентов */
+}
+
+
+/* Камера и ореол – в серый */
+.camera-icon { color: #525252; }         /* gray-600 */
+.camera-wrap::before,
+.camera-wrap::after { display: none !important; } /* убираем пульсации/ореолы, если были */
+
+/* Нейтральные «мягкие» кнопки (вместо оранжевых) */
+.btn-soft {
+  background: #f5f5f5;           /* gray-100 */
+  color: #0a0a0a;
+  border: 1px solid #e5e7eb;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+.btn-soft:hover {
+  background: #eeeeee;           /* чуть темнее */
+  border-color: #d1d5db;         /* gray-300 */
+}
+
+/* Сегменты единиц (g/ml/pcs) – серые */
+.seg {
+  display: inline-flex;
+  background: #f5f5f5;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 2px;
+}
+.seg-btn {
+  padding: 6px 10px;
+  border-radius: 10px;
+  font-size: 13px;
+  color: #111827;               /* gray-900 */
+}
+.seg-btn[aria-pressed="true"] {
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+}
+
+/* ЕДИНСТВЕННАЯ оранжевая кнопка — CTA */
+.btn-peach {
+  background: linear-gradient(180deg, #f39a6a 0%, #e6865b 100%);
+  color: #fff;
+}
+.btn-peach:hover { filter: brightness(0.98); }
+.btn-peach:disabled { opacity: .4; }
+
+
 
 /* тёмная тема */
 .dark {
@@ -121,11 +158,10 @@
 }
 
 @layer base {
-  * {
-    @apply border-border; /* убрали outline-ring/50 — это невалидный класс */
-  }
+  * { @apply border-border; }
   body {
     @apply bg-background text-foreground;
+    font-family: "Manrope", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Apple Color Emoji","Segoe UI Emoji";
   }
 }
 
@@ -135,3 +171,152 @@
 
 /* приятнее тапы на iOS */
 * { -webkit-tap-highlight-color: rgba(0,0,0,0); }
+
+/* ===================== UTILITIES ===================== */
+@layer utilities {
+  /* ---------- BACKDROP (как на референсе) ---------- */
+  .app-gradient {
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    background:
+      radial-gradient(1200px 800px at 12% 16%, rgba(255, 200, 168, .38), transparent 60%),
+      radial-gradient(900px 700px at 84% 12%, rgba(255, 230, 208, .45), transparent 60%),
+      radial-gradient(1100px 900px at 50% 100%, rgba(255, 214, 186, .42), transparent 60%),
+      linear-gradient(180deg, var(--peach-1) 0%, var(--peach-2) 48%, var(--peach-3) 100%);
+  }
+.app-gradient::before {
+  content: "";
+  position: absolute; inset: 0;
+  background:
+    radial-gradient(120% 100% at 0% 0%, rgba(255,255,255,.25), transparent 40%),
+    radial-gradient(100% 120% at 100% 100%, rgba(255,255,255,.18), transparent 42%),
+    conic-gradient(from 200deg at 20% 0%, rgba(255,255,255,.04), transparent 25% 60%, rgba(255,255,255,.04) 80%, transparent 100%);
+  mix-blend-mode: screen;
+  animation: bg-shift 16s ease-in-out infinite alternate;
+  pointer-events: none;
+}
+
+  @keyframes bg-shift {
+    0%   { transform: translateY(0);   filter: hue-rotate(0deg)   saturate(1); }
+    100% { transform: translateY(-1%); filter: hue-rotate(-6deg) saturate(1.05); }
+  }
+
+  /* ---------- UNIFIED GLASS CARD ---------- */
+  /* Совместимость: .glass и .glass-card — одно и то же */
+  .glass-card, .glass {
+    position: relative;
+    background: rgba(255,255,255,.78);
+    border: 1px solid rgba(255,255,255,.66);
+    border-radius: 24px;
+    -webkit-backdrop-filter: blur(22px) saturate(1.08);
+    backdrop-filter: blur(22px) saturate(1.08);
+    box-shadow:
+      0 24px 48px rgba(240, 154, 121, .18),
+      0 8px 18px rgba(240, 154, 121, .12),
+      inset 0 1px 0 rgba(255,255,255,.85);
+  }
+.glass-card::before, .glass::before {
+  content: "";
+  position: absolute; inset: 0; border-radius: inherit;
+  background:
+    radial-gradient(140% 120% at 10% 8%, rgba(255,255,255,.48), transparent 36%),
+    radial-gradient(120% 120% at 90% 92%, rgba(255,255,255,.22), transparent 42%);
+  pointer-events: none;
+}
+
+  /* совместимость со старым классом */
+  .glass-border { border-color: rgba(255,255,255,.66); }
+
+  /* ---------- PRIMARY CTA (персиковая) ---------- */
+  .btn-peach {
+    background: linear-gradient(135deg, var(--peach-4) 0%, var(--peach-5) 35%, var(--peach-6) 65%, var(--peach-4) 100%);
+    background-size: 200% 200%;
+    color: #fff;
+    box-shadow:
+      0 10px 28px rgba(244, 167, 120, .38),
+      0 3px 10px rgba(240, 154, 121, .28);
+    animation: gradient-move 6s ease infinite;
+  }
+  .btn-peach:hover { filter: brightness(1.02); }
+  .btn-peach:active { transform: translateY(1px) scale(.995); }
+  @keyframes gradient-move {
+    0% { background-position: 0% 50%; }
+    50% { background-position: 100% 50%; }
+    100% { background-position: 0% 50%; }
+  }
+
+  /* ---------- Secondary pills (+ Добавить / × Очистить) ---------- */
+  .btn-soft {
+    background: rgba(255,255,255,.7);
+    border: 1px solid rgba(255,255,255,.55);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,.8);
+    animation: soft-glow 3.4s ease-in-out infinite;
+  }
+  @keyframes soft-glow {
+    0%,100% {
+      box-shadow:
+        0 10px 24px rgba(244,167,120,.18),
+        0 3px 10px rgba(244,167,120,.12),
+        inset 0 1px 0 rgba(255,255,255,.8);
+    }
+    50% {
+      box-shadow:
+        0 14px 30px rgba(244,167,120,.28),
+        0 4px 12px rgba(244,167,120,.18),
+        inset 0 1px 0 rgba(255,255,255,.8);
+    }
+  }
+
+  /* ---------- Камера с аурой ---------- */
+  .camera-wrap {
+    position: relative;
+    width: 112px; height: 112px;
+    border-radius: 9999px;
+    background: radial-gradient(60px 60px at 50% 50%, rgba(255,255,255,.9), rgba(255,255,255,.6));
+    border: 2px solid rgba(255, 175, 143, .8);
+    box-shadow:
+      0 8px 30px rgba(244, 167, 120, .28),
+      inset 0 2px 8px rgba(255,255,255,.9);
+  }
+ .camera-wrap::after { display: none !important; }
+
+/* кольцо вокруг камеры – серое */
+.camera-wrap {
+  border: 2px solid #d1d5db !important;   /* gray-300 */
+  border-radius: 9999px;
+  padding: 18px;                           /* чтобы было «кольцо» */
+  box-shadow: none !important;             /* без персиковых теней */
+}
+  .camera-icon { color: #f28f6d; animation: cam-breathe 3s ease-in-out infinite; }
+  @keyframes aura   { 0%,100% { opacity:.6; transform:scale(1);} 50% { opacity:.9; transform:scale(1.05);} }
+  @keyframes cam-breathe { 0%,100% { transform:scale(1);} 50% { transform:scale(1.06);} }
+
+  /* ---------- Сегмент-контрол (г/мл/шт) ---------- */
+  .seg {
+    display: inline-flex; gap: 8px; padding: 6px; border-radius: 9999px;
+    background: rgba(255,255,255,.7);
+    border: 1px solid rgba(255,255,255,.55);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,.8);
+  }
+  .seg-btn {
+    min-width: 44px; padding: 8px 12px; border-radius: 12px; font-weight: 700;
+    color: #9a6a56; letter-spacing: .02em;
+    transition: transform .15s ease, background .2s ease, color .2s ease;
+  }
+  .seg-btn[aria-pressed="true"] {
+    background: #ef8f6b; color: #fff;
+    box-shadow: 0 8px 18px rgba(239, 143, 107, .28), inset 0 1px 0 rgba(255,255,255,.6);
+  }
+  .seg-btn:active { transform: translateY(1px); }
+}
+
+/* мягкая вуаль сверху карточки для лучшего контраста текста */
+.glass-contrast::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(180deg, rgba(255,255,255,.65), rgba(255,255,255,.28) 28%, transparent 60%);
+  pointer-events: none;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,19 +13,22 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ru">
-      <body className="min-h-dvh bg-white text-gray-900 safe-top safe-bottom">
-        {/* Инициализация аналитики: cookie uid + sessionId + auto app_open */}
+      <body className="relative min-h-dvh text-gray-900 safe-top safe-bottom overflow-x-hidden">
+        {/* === Анимированный градиентный фон === */}
+        <div className="app-gradient" />
+
+        {/* === Инициализация аналитики === */}
         <InitAnalytics />
 
-        {/* Модалка согласия — включит аналитику после клика "Разрешить" */}
+        {/* === Модалка согласия === */}
         <ConsentModal />
 
-        {/* Основной контент */}
-        <main className="mx-auto max-w-5xl px-4 py-6">
+        {/* === Основной контент === */}
+        <main className="relative z-10 mx-auto max-w-5xl px-4 py-6">
           {children}
         </main>
 
-        {/* Плавающая кнопка "Настройки" внизу справа */}
+        {/* === Плавающая кнопка "Настройки" === */}
         <FabSettings />
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,6 @@ import UploadZone from "@/components/ui/upload-zone";
 import ConfirmProductsPanel from "@/components/confirm-products-panel";
 import ProgressButton from "@/components/ProgressButton";
 
-// Тип согласован с confirm-products-panel.tsx
 type ProductQty = {
   name: string;
   detailed?: boolean;
@@ -15,11 +14,8 @@ type ProductQty = {
 };
 
 export default function HomePage() {
-  // имена (для совместимости с ?items=)
   const [recognized, setRecognized] = useState<string[]>([]);
-  // полный формат (для опциональных количеств)
   const [recognizedQty, setRecognizedQty] = useState<ProductQty[]>([]);
-
   const [isScanning, setIsScanning] = useState(false);
   const [manualMode, setManualMode] = useState(false);
   const [flashConfirm, setFlashConfirm] = useState(false);
@@ -39,7 +35,6 @@ export default function HomePage() {
   const handleRecognized = (products: string[]) => {
     const names = products.map((s) => s.trim()).filter(Boolean);
     setRecognized(names);
-    // стартово все без уточнения количества
     setRecognizedQty(names.map((n) => ({ name: n, detailed: false })));
     setIsScanning(false);
     setManualMode(false);
@@ -64,99 +59,96 @@ export default function HomePage() {
     setManualMode(false);
   };
 
-  // после сканирования и при наличии продуктов — уменьшаем блок с фото
   const compactPhoto = !isScanning && recognized.length > 0;
 
-  // Переход на /recipes — без ожидания сервера
   const generateRecipes = async () => {
     setErrorMsg(null);
-
     const items = recognized.map((s) => s.trim()).filter(Boolean);
     if (items.length === 0) {
       throw new Error("Добавьте продукты, чтобы показать рецепт");
     }
-
-    // в сессию положим только уточнённые позиции
     try {
       const detailed = recognizedQty
         .filter((i) => i.detailed && typeof i.qty === "number" && i.unit)
-        .map((i) => ({
-          name: i.name.trim(),
-          qty: i.qty as number,
-          unit: i.unit as "g" | "ml" | "pcs",
-        }));
+        .map((i) => ({ name: i.name.trim(), qty: i.qty as number, unit: i.unit as "g" | "ml" | "pcs" }));
       sessionStorage.setItem("products_qty", JSON.stringify(detailed));
     } catch {}
-
     try {
       sessionStorage.removeItem("recipes_payload");
     } catch {}
-
     const q = encodeURIComponent(items.join(","));
     router.replace(`/recipes?items=${q}`);
   };
 
   return (
-      <main className="p-6 max-w-md mx-auto space-y-6 text-center">
-    <h1 className="text-xl font-semibold">Что сегодня готовим, Шеф?</h1>
+    <main className="p-6 max-w-md mx-auto space-y-6 text-center">
+      <h1 className="text-2xl font-extrabold tracking-tight text-[#1e1e1e]">
+        <span>Что сегодня готовим, Шеф?</span>
+      </h1>
 
-    {/* Обёртка с плавным изменением высоты */}
-    <div
-      className={[
-        "transition-all duration-500 ease-out overflow-hidden",
-        compactPhoto ? "max-h-40 sm:max-h-48" : "max-h-[22rem] sm:max-h-[28rem]",
-      ].join(" ")}
-    >
-      <UploadZone
-        compact={compactPhoto}
-        onRecognized={handleRecognized}
-        onScanningChange={setIsScanning}
-      />
-       </div>
+      {/* Карточка загрузки фото — единое «стекло» */}
+      <div
+        className={[
+          "glass-card rounded-3xl",
+          "transition-all duration-500 ease-out overflow-hidden",
+          compactPhoto ? "p-3" : "p-0",
+        ].join(" ")}
+      >
+        <div
+          className={[
+            "transition-all duration-500 ease-out",
+            compactPhoto ? "max-h-40 sm:max-h-48" : "max-h-[22rem] sm:max-h-[28rem]",
+          ].join(" ")}
+        >
+          <UploadZone
+            compact={compactPhoto}
+            onRecognized={handleRecognized}
+            onScanningChange={setIsScanning}
+          />
+        </div>
+      </div>
 
-      {isScanning && <p className="text-sm text-gray-500">Распознаём продукты…</p>}
+      {isScanning && <p className="text-sm text-gray-600">Распознаём продукты…</p>}
 
       {shouldShowManualButton && (
         <button
           type="button"
           onClick={handleManualClick}
-          className="w-full rounded-xl border px-4 py-3 text-sm hover:bg-gray-50"
+          className="w-full rounded-2xl px-4 py-3 text-sm glass-card hover:shadow-md transition"
         >
           Написать продукты вручную
         </button>
       )}
 
-      {shouldShowPanel && (
-        <div
-          ref={confirmRef}
-          className={
-            flashConfirm
-              ? "rounded-xl ring-2 ring-black/10 animate-[pulse_0.6s_ease-in-out_2]"
-              : ""
-          }
+     {shouldShowPanel && (
+      <div
+        ref={confirmRef}
+        className={[
+          "glass rounded-3xl border glass-border p-4 text-left", // ❌ убрали glass-glow
+         "text-slate-900", // базовый тёмный цвет текста
+          flashConfirm ? "ring-2 ring-black/10 animate-[pulse_0.6s_ease-in-out_2]" : "",
+        ].join(" ")}
         >
+
+
+
           <ConfirmProductsPanel
             initialItems={recognized}
-            // имена для обратной совместимости родителя
             onChange={setRecognized}
-            // ВАЖНО: обёртка, чтобы тип функции совпал
             onChangeQty={(list) => setRecognizedQty(list)}
             onClear={handleClearPanel}
             hideAction
           />
 
-          {/* Прогресс-кнопка «Показать рецепт» */}
+          {/* CTA «Показать рецепт» — персиковый градиент */}
           <div className="mt-4">
             <ProgressButton
               onStart={generateRecipes}
               idleText="Показать рецепт"
-              onError={(e) =>
-                setErrorMsg(e instanceof Error ? e.message : "Что-то пошло не так")
-              }
+              onError={(e) => setErrorMsg(e instanceof Error ? e.message : "Что-то пошло не так")}
+              className="btn-peach w-full rounded-[28px] px-6 py-4 font-medium focus:outline-none focus:ring-2 focus:ring-white/30"
             />
-            {errorMsg && (
-              <p className="mt-2 text-sm text-red-500">Ошибка: {errorMsg}</p>
-            )}
+            {errorMsg && <p className="mt-2 text-sm text-red-500">Ошибка: {errorMsg}</p>}
           </div>
         </div>
       )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -59,7 +59,9 @@ export default function HomePage() {
     setManualMode(false);
   };
 
-  const compactPhoto = !isScanning && recognized.length > 0;
+  // схлопывать, если уже есть распознанные ИЛИ пользователь включил ручной ввод
+  const compactPhoto = !isScanning && (recognized.length > 0 || manualMode);
+
 
   const generateRecipes = async () => {
     setErrorMsg(null);
@@ -81,8 +83,8 @@ export default function HomePage() {
   };
 
   return (
-    <main className="p-6 max-w-md mx-auto space-y-6 text-center">
-      <h1 className="text-2xl font-extrabold tracking-tight text-[#1e1e1e]">
+    <main className="p-6 mx-auto space-y-6 text-center max-w-xl sm:max-w-2xl">
+      <h1 className="whitespace-nowrap text-[22px] sm:text-3xl md:text-4xl font-extrabold tracking-tight text-[#1e1e1e] leading-tight">
         <span>Что сегодня готовим, Шеф?</span>
       </h1>
 

--- a/src/app/recipes/page.tsx
+++ b/src/app/recipes/page.tsx
@@ -20,23 +20,32 @@ export default function RecipesPage() {
 
   if (products.length === 0) {
     return (
-      <main className="p-6 max-w-2xl mx-auto">
-        <h1 className="text-2xl font-semibold mb-4">Ваши рецепты</h1>
-        <p className="text-sm text-gray-500">
-          Сначала добавьте продукты на главной странице.
-        </p>
+      <main className="p-6 mx-auto space-y-6 text-center max-w-xl sm:max-w-2xl">
+        <h1 className="whitespace-nowrap text-[22px] sm:text-3xl md:text-4xl font-extrabold tracking-tight text-[#1e1e1e] leading-tight">
+          Ваши рецепты
+        </h1>
+        <section className="glass rounded-3xl border glass-border p-4 text-left text-slate-900">
+          <p className="text-sm text-gray-600">
+            Сначала добавьте продукты на главной странице.
+          </p>
+        </section>
       </main>
     );
   }
 
   return (
-    <main className="p-6 space-y-6 max-w-2xl mx-auto">
-      <h1 className="text-2xl font-semibold">Ваши рецепты</h1>
+    <main className="p-6 mx-auto space-y-6 text-center max-w-xl sm:max-w-2xl">
+      <h1 className="whitespace-nowrap text-[22px] sm:text-3xl md:text-4xl font-extrabold tracking-tight text-[#1e1e1e] leading-tight">
+        Ваши рецепты
+      </h1>
 
-      {/* Только стрим: два рецепта печатаются сразу, третий — по клику */}
-      <StreamedRecipesDemo products={products} />
-
-      {/* Если позже понадобится — сюда вернём карточки на основе распарсенного стрима */}
+      {/* стеклянная зона контента — как на главной */}
+      <section className="glass rounded-3xl border glass-border p-4 text-left text-slate-900">
+        {/* сам стрим рецептов */}
+        <div className="grid gap-4">
+          <StreamedRecipesDemo products={products} hideTitle />
+        </div>
+      </section>
     </main>
   );
 }

--- a/src/components/ProgressButton.tsx
+++ b/src/components/ProgressButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { ChefHat } from "lucide-react";
 
 type Props = {
   onStart: () => Promise<void>;
@@ -40,25 +41,18 @@ export default function ProgressButton({
     };
   }, [loading]);
 
-  // логика показа подсказки: включается через hintDelayMs после достижения >=90%, исчезает на 100% или при остановке
+  // показ подсказки при 90–99%
   useEffect(() => {
-    // сброс хинта, если ушли с 90–99 или прекратили загрузку
     if (!loading || progress < 90 || progress >= 100) {
       setShowHint(false);
       if (hintTimerRef.current) window.clearTimeout(hintTimerRef.current);
       hintTimerRef.current = null;
       return;
     }
-
-    // если уже идёт таймер — не ставим второй
     if (hintTimerRef.current == null) {
-      hintTimerRef.current = window.setTimeout(() => {
-        setShowHint(true);
-      }, hintDelayMs);
+      hintTimerRef.current = window.setTimeout(() => setShowHint(true), hintDelayMs);
     }
-
     return () => {
-      // если deps изменились (например, прогресс прыгнул назад — на всякий), то сбросим
       if (progress < 90 || progress >= 100 || !loading) {
         if (hintTimerRef.current) window.clearTimeout(hintTimerRef.current);
         hintTimerRef.current = null;
@@ -78,7 +72,6 @@ export default function ProgressButton({
     setLoading(true);
     try {
       await onStart();
-      // добегаем до 100 после успешного завершения
       setProgress(100);
       await new Promise((r) => setTimeout(r, 350));
     } catch (e) {
@@ -95,37 +88,76 @@ export default function ProgressButton({
   };
 
   return (
-    <button
-      type="button"
-      onClick={handleClick}
-      disabled={loading}
-      className={`relative w-full rounded-2xl border border-border bg-background/60 backdrop-blur p-3 text-sm font-medium transition enabled:hover:shadow-md disabled:opacity-80 ${className}`}
-      aria-busy={loading}
-      aria-live="polite"
-    >
-      {!loading && <span>{idleText}</span>}
+    <div className={`relative`}>
+      {/* мягкое «свечение» вокруг кнопки */}
+      <div className="pointer-events-none absolute -inset-3 rounded-[32px] opacity-80 blur-lg"
+           style={{
+             background: "radial-gradient(60% 80% at 50% 50%, rgba(244, 167, 120, 0.45), rgba(244, 167, 120, 0.18) 60%, transparent 70%)"
+           }} />
 
-      {loading && (
-        <>
-          <div className="flex items-center gap-2">
-            <span className="shrink-0">Готовим…</span>
-            <span className="ml-auto tabular-nums">{Math.round(progress)}%</span>
-          </div>
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={loading}
+        className={
+          // основная «пилюля» с живым градиентом
+          `relative z-[1] w-full rounded-[28px] px-6 py-4 text-white font-medium shadow-lg 
+           transition active:scale-[0.99] focus:outline-none focus:ring-2 focus:ring-white/30
+           disabled:opacity-80 disabled:cursor-not-allowed
+           ${className}`
+        }
+        style={{
+          background:
+            "linear-gradient(135deg, #F6B089 0%, #F09A79 25%, #F29D7B 50%, #F6B089 75%, #F09A79 100%)",
+          backgroundSize: "200% 200%",
+          animation: "gradient-move 6s ease infinite",
+          boxShadow:
+            "0 8px 24px rgba(244, 167, 120, 0.45), 0 2px 8px rgba(240, 154, 121, 0.35)",
+        }}
+        aria-busy={loading}
+        aria-live="polite"
+      >
+        {!loading && (
+          <span className="inline-flex items-center gap-2 justify-center">
+            <ChefHat size={18} className="opacity-95" />
+            {idleText}
+          </span>
+        )}
 
-          <div className="mt-2 h-2 w-full overflow-hidden rounded-full border border-border/60" aria-hidden>
-            <div
-              className="h-full w-0 transition-[width] duration-200 bg-foreground/70"
-              style={{ width: `${progress}%` }}
-            />
-          </div>
+        {loading && (
+          <>
+            <div className="flex items-center gap-2">
+              <span className="shrink-0">Готовим…</span>
+              <span className="ml-auto tabular-nums text-white/90">
+                {Math.round(progress)}%
+              </span>
+            </div>
 
-          {showHint && (
-            <p className="mt-2 text-xs text-gray-500 animate-pulse">
-              {hintText}
-            </p>
-          )}
-        </>
-      )}
-    </button>
+            {/* прогресс-бар на оранжевом фоне — светлый */}
+            <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-white/25" aria-hidden>
+              <div
+                className="h-full w-0 transition-[width] duration-200 bg-white"
+                style={{ width: `${progress}%` }}
+              />
+            </div>
+
+            {showHint && (
+              <p className="mt-2 text-xs text-white/85 animate-pulse">
+                {hintText}
+              </p>
+            )}
+          </>
+        )}
+      </button>
+
+      {/* keyframes прямо в компоненте */}
+      <style jsx>{`
+        @keyframes gradient-move {
+          0%   { background-position: 0% 50%; }
+          50%  { background-position: 100% 50%; }
+          100% { background-position: 0% 50%; }
+        }
+      `}</style>
+    </div>
   );
 }

--- a/src/components/confirm-products-panel.tsx
+++ b/src/components/confirm-products-panel.tsx
@@ -4,29 +4,21 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import type { RecipeDto } from "@/types/recipe";
 import { track, getSessionId } from "@/lib/analytics";
+import { X } from "lucide-react";
 
 type Unit = "g" | "ml" | "pcs";
-type ProductQty = {
-  name: string;
-  detailed?: boolean;   // пользователь включил "уточнить"
-  qty?: number;         // только если detailed = true
-  unit?: Unit;          // только если detailed = true
-};
-
+type ProductQty = { name: string; detailed?: boolean; qty?: number; unit?: Unit };
 type ConfirmProductsPanelProps = {
-  initialItems?: string[];              // как раньше
+  initialItems?: string[];
   onClear?: () => void;
-  onChange?: (items: string[]) => void; // совместимость по именам
+  onChange?: (items: string[]) => void;
   hideAction?: boolean;
-  onChangeQty?: (items: ProductQty[]) => void; // новый полный формат
+  onChangeQty?: (items: ProductQty[]) => void;
 };
-
 type RecipeWithLead = RecipeDto & { lead?: string };
 
-const norm = (s: string) =>
-  s.toLowerCase().trim().replace(/\s+/g, " ").replace(/ё/g, "е");
+const norm = (s: string) => s.toLowerCase().trim().replace(/\s+/g, " ").replace(/ё/g, "е");
 
-// простая эвристика по единицам
 function defaultUnitFor(name: string): Unit {
   const n = norm(name);
   const isLiquid = /(молок|сливк|вода|соус|масло|йогурт|кефир|морожен|бульон|сок|напит|молочн|слив)/.test(n);
@@ -55,20 +47,14 @@ export default function ConfirmProductsPanel({
 
   const emitChange = (next: ProductQty[]) => {
     const key = next
-      .map((i) =>
-        i.detailed
-          ? `${norm(i.name)}:${i.qty ?? ""}${i.unit ?? ""}`
-          : `${norm(i.name)}`
-      )
+      .map((i) => (i.detailed ? `${norm(i.name)}:${i.qty ?? ""}${i.unit ?? ""}` : `${norm(i.name)}`))
       .join("|");
     if (key === lastEmittedRef.current) return;
     lastEmittedRef.current = key;
-
     onChange?.(next.map((i) => i.name));
     onChangeQty?.(next);
   };
 
-  // старт: строки -> ProductQty с detailed=false
   const normalizedInitial = useMemo<ProductQty[]>(() => {
     const seen = new Set<string>();
     const result: ProductQty[] = [];
@@ -83,21 +69,14 @@ export default function ConfirmProductsPanel({
     return result;
   }, [initialItems]);
 
-  // 🔧 фикс мигалок: гидратим только один раз (или если пришёл новый набор и локальный список пуст)
   const initialKeyRef = useRef<string>("");
   const initialKey = useMemo(
-    () =>
-      (initialItems ?? [])
-        .map((x) => norm(String(x)))
-        .filter(Boolean)
-        .sort()
-        .join("|"),
+    () => (initialItems ?? []).map((x) => norm(String(x))).filter(Boolean).sort().join("|"),
     [initialItems]
   );
 
   useEffect(() => {
     const currentNamesKey = items.map((i) => norm(i.name)).sort().join("|");
-
     if (!initialKeyRef.current) {
       setItems(normalizedInitial);
       lastEmittedRef.current = normalizedInitial
@@ -106,7 +85,6 @@ export default function ConfirmProductsPanel({
       initialKeyRef.current = initialKey;
       return;
     }
-
     if (initialKey !== initialKeyRef.current && items.length === 0 && currentNamesKey === "") {
       setItems(normalizedInitial);
       lastEmittedRef.current = normalizedInitial
@@ -115,25 +93,21 @@ export default function ConfirmProductsPanel({
       initialKeyRef.current = initialKey;
       return;
     }
-    // иначе ничего не делаем
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialKey, normalizedInitial]);
 
-  // === добавление ===
   const canAdd = nameInput.trim().length > 0;
 
   const handleAdd = () => {
     if (!canAdd) return;
     const name = nameInput.trim();
     const k = norm(name);
-
     const existsIdx = items.findIndex((i) => norm(i.name) === k);
     if (existsIdx >= 0) {
       setNameInput("");
       setQtyInput("");
       return;
     }
-
     const next = [...items, { name, detailed: false }];
     setItems(next);
     emitChange(next);
@@ -153,18 +127,15 @@ export default function ConfirmProductsPanel({
     onClear?.();
   };
 
-  // === редактирование строки ===
   const toggleDetailed = (idx: number) => {
     const next = [...items];
     const it = next[idx];
-
     if (!it.detailed) {
       const unit = defaultUnitFor(it.name);
       next[idx] = { ...it, detailed: true, unit, qty: 1 };
     } else {
       next[idx] = { ...it, detailed: false, qty: undefined, unit: undefined };
     }
-
     setItems(next);
     emitChange(next);
   };
@@ -176,7 +147,6 @@ export default function ConfirmProductsPanel({
     emitChange(next);
   };
 
-  // === кэш-ключ: учитываем qty/unit ТОЛЬКО для detailed ===
   const makeCacheKey = (arr: ProductQty[]) => {
     const mapped = arr.map((i) => ({
       n: norm(i.name),
@@ -185,12 +155,7 @@ export default function ConfirmProductsPanel({
       u: i.detailed ? i.unit : undefined,
     }));
     mapped.sort((a, b) => (a.n < b.n ? -1 : a.n > b.n ? 1 : 0));
-    return (
-      "recipes:" +
-      mapped
-        .map((i) => (i.d ? `${i.n}:${i.q}${i.u}` : i.n))
-        .join("|")
-    );
+    return "recipes:" + mapped.map((i) => (i.d ? `${i.n}:${i.q}${i.u}` : i.n)).join("|");
   };
 
   const onNameKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -203,7 +168,6 @@ export default function ConfirmProductsPanel({
   async function handleGenerate() {
     if (items.length === 0 || submitting) return;
     setSubmitting(true);
-
     const key = makeCacheKey(items);
     const names = items.map((i) => i.name);
     const detailedItems = items
@@ -216,62 +180,42 @@ export default function ConfirmProductsPanel({
       });
 
     try {
-      // 0) client-cache
       try {
         const cachedRaw = localStorage.getItem(key);
         if (cachedRaw) {
           const enriched = JSON.parse(cachedRaw);
-          sessionStorage.setItem(
-            "recipes_payload",
-            JSON.stringify({ products: names, data: enriched })
-          );
+          sessionStorage.setItem("recipes_payload", JSON.stringify({ products: names, data: enriched }));
           router.replace(`/recipes?items=${encodeURIComponent(names.join(","))}`);
           return;
         }
       } catch {}
 
-      // 👉 аналитика до реального запроса
       try {
         track("recipes_requested", { mode: "default", productsCount: names.length });
       } catch {}
 
-      // 1) запрос
       sessionStorage.removeItem("recipes_payload");
       const sid = getSessionId?.();
 
       const res = await fetch("/api/recipes", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...(sid ? { "x-session-id": sid } : {}),
-        },
-        body: JSON.stringify({
-          products: names,       // как раньше — список имён
-          items: detailedItems,  // НОВОЕ: только уточнённые позиции
-        }),
+        headers: { "Content-Type": "application/json", ...(sid ? { "x-session-id": sid } : {}) },
+        body: JSON.stringify({ products: names, items: detailedItems }),
       });
 
       if (!res.ok) throw new Error(`Ошибка сервера (${res.status})`);
-
       const json = await res.json();
 
-      // 2) приклеиваем lead по индексу
-      const withLead: RecipeWithLead[] = (json.recipes ?? []).map(
-        (r: RecipeDto, i: number) => ({
-          ...r,
-          lead: json?.trace?.leads?.[i] ?? undefined,
-        })
-      );
+      const withLead: RecipeWithLead[] = (json.recipes ?? []).map((r: RecipeDto, i: number) => ({
+        ...r,
+        lead: json?.trace?.leads?.[i] ?? undefined,
+      }));
       const enriched = { ...json, recipes: withLead };
 
-      // 3) client-cache и session
       try {
         localStorage.setItem(key, JSON.stringify(enriched));
       } catch {}
-      sessionStorage.setItem(
-        "recipes_payload",
-        JSON.stringify({ products: names, data: enriched })
-      );
+      sessionStorage.setItem("recipes_payload", JSON.stringify({ products: names, data: enriched }));
 
       router.replace(`/recipes?items=${encodeURIComponent(names.join(","))}`);
     } catch (e) {
@@ -282,148 +226,168 @@ export default function ConfirmProductsPanel({
     }
   }
 
-  return (
-    <section className="p-6 max-w-md mx-auto space-y-4">
-      <h2 className="text-xl font-semibold">Подтвердите список продуктов</h2>
-      <p className="-mt-2 text-sm text-gray-500 leading-tight">
-        Добавьте продукты вручную<br />или сфотографируйте их
-      </p>
+// ... импорт/типы оставь как есть выше
+// замени return на этот (остальной код файла – без изменений)
 
-      {/* Список с тумблером «Уточнить» */}
-      {items.length > 0 && (
-        <ul className="space-y-2">
-          {items.map((it, i) => (
-            <li
-              key={`${it.name}-${i}`}
-              className="border rounded-lg p-3 space-y-2"
+return (
+  <section className="p-6 max-w-md mx-auto space-y-4">
+    {/* Заголовок */}
+    <h2 className="text-2xl font-extrabold tracking-tight text-[#1e1e1e]">
+      Уточни список продуктов
+    </h2>
+
+
+    {/* Список продуктов */}
+    {items.length > 0 && (
+      <ul className="space-y-2">
+        {items.map((it, i) => (
+          <li
+            key={`${it.name}-${i}`}
+            className="rounded-2xl border bg-white shadow-sm p-3 space-y-3"
+          >
+            <div className="flex items-center gap-2">
+              <input
+                className="flex-1 rounded-lg border bg-white px-3 py-2 text-sm text-[#1e1e1e] placeholder:text-[#777] focus:outline-none focus:ring-2 focus:ring-gray-300"
+                value={it.name}
+                onChange={(e) => updateItem(i, { name: e.target.value })}
+              />
+              <button
+                type="button"
+                onClick={() => handleRemove(it.name)}
+                className="text-gray-400 hover:text-gray-600 transition p-1"
+                aria-label="Удалить"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M18 6 6 18M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+
+            {/* Уточнение количества */}
+            <button
+              type="button"
+              onClick={() => toggleDetailed(i)}
+              aria-expanded={!!it.detailed}
+              className="flex w-full items-center gap-2 text-[15px] font-semibold text-gray-900"
             >
-              <div className="flex items-center gap-2">
+              <svg
+                className={`transition-transform ${it.detailed ? "rotate-180" : ""}`}
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="#6b7280"
+                strokeWidth="2"
+              >
+                <path d="m6 9 6 6 6-6" />
+              </svg>
+              Уточнить количество
+            </button>
+
+            {it.detailed && (
+              <div className="grid grid-cols-[1fr_auto] gap-3 items-center">
                 <input
-                  className="flex-1 border rounded px-2 py-1 text-sm"
-                  value={it.name}
-                  onChange={(e) => updateItem(i, { name: e.target.value })}
+                  type="number"
+                  min={1}
+                  step={it.unit === "pcs" ? 1 : 50}
+                  className="w-full rounded-lg border bg-white px-3 py-2 text-sm text-[#1e1e1e] placeholder:text-[#777] focus:outline-none focus:ring-2 focus:ring-gray-300"
+                  value={it.qty === undefined ? "" : it.qty}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    if (v === "") {
+                      updateItem(i, { qty: undefined });
+                      return;
+                    }
+                    const num = Number(v);
+                    if (!Number.isNaN(num)) updateItem(i, { qty: num });
+                  }}
+                  onBlur={() => {
+                    const current = items[i]?.qty;
+                    let nextQty =
+                      current === undefined ||
+                      Number.isNaN(Number(current)) ||
+                      Number(current) <= 0
+                        ? 1
+                        : Number(current);
+                    if (items[i]?.unit === "pcs") {
+                      nextQty = Math.max(1, Math.round(nextQty));
+                    }
+                    if (nextQty !== current) updateItem(i, { qty: nextQty });
+                  }}
+                  inputMode="numeric"
+                  placeholder="0"
                 />
-                <button
-                  type="button"
-                  onClick={() => handleRemove(it.name)}
-                  className="text-red-500 text-xs hover:underline whitespace-nowrap"
-                >
-                  удалить
-                </button>
-              </div>
 
-              <div className="flex items-center gap-3">
-                <label className="inline-flex items-center gap-2 text-sm">
-                  <input
-                    type="checkbox"
-                    checked={!!it.detailed}
-                    onChange={() => toggleDetailed(i)}
-                  />
-                  Уточнить количество
-                </label>
-
-                {it.detailed && (
-                  <>
-                    <input
-                      type="number"
-                      min={1}
-                      step={it.unit === "pcs" ? 1 : 50}
-                      className="w-24 border rounded px-2 py-1 text-sm"
-                      value={it.qty === undefined ? "" : it.qty}
-                      onChange={(e) => {
-                        const v = e.target.value;
-                        if (v === "") {
-                          updateItem(i, { qty: undefined });
-                          return;
-                        }
-                        const num = Number(v);
-                        if (!Number.isNaN(num)) {
-                          updateItem(i, { qty: num });
-                        }
-                      }}
-                      onBlur={() => {
-                        const current = items[i]?.qty;
-                        let nextQty =
-                          current === undefined || Number.isNaN(Number(current)) || Number(current) <= 0
-                            ? 1
-                            : Number(current);
-
-                        if (items[i]?.unit === "pcs") {
-                          nextQty = Math.round(nextQty);
-                          if (nextQty < 1) nextQty = 1;
-                        }
-
-                        if (nextQty !== current) {
-                          updateItem(i, { qty: nextQty });
-                        }
-                      }}
-                      inputMode="numeric"
-                    />
-
-                    <select
-                      className="w-24 border rounded px-2 py-1 text-sm"
-                      value={it.unit ?? defaultUnitFor(it.name)}
-                      onChange={(e) =>
-                        updateItem(i, { unit: e.target.value as Unit })
-                      }
+                <div className="seg">
+                  {(["g", "ml", "pcs"] as const).map((u) => (
+                    <button
+                      key={u}
+                      type="button"
+                      className="seg-btn"
+                      aria-pressed={(it.unit ?? defaultUnitFor(it.name)) === u}
+                      onClick={() => updateItem(i, { unit: u })}
                     >
-                      <option value="g">г</option>
-                      <option value="ml">мл</option>
-                      <option value="pcs">шт</option>
-                    </select>
-                  </>
-                )}
+                      {u === "g" ? "г" : u === "ml" ? "мл" : "шт"}
+                    </button>
+                  ))}
+                </div>
               </div>
-            </li>
-          ))}
-        </ul>
-      )}
+            )}
+          </li>
+        ))}
+      </ul>
+    )}
 
-      {/* Ряд добавления */}
-      <div className="flex items-end gap-2">
-        <div className="flex-1">
-          <input
-            type="text"
-            value={nameInput}
-            onChange={(e) => setNameInput(e.target.value)}
-            onKeyDown={onNameKeyDown}
-            placeholder="Например: огурец"
-            className="w-full border rounded-lg px-3 py-2 text-sm"
-            autoComplete="off"
-          />
-        </div>
-        <button
-          type="button"
-          onClick={handleAdd}
-          disabled={!nameInput.trim()}
-          className="shrink-0 whitespace-nowrap rounded-lg bg-black text-white px-4 py-2 text-sm hover:bg-black/90 disabled:opacity-40 disabled:cursor-not-allowed"
-        >
-          Добавить
-        </button>
+    {/* Добавление продукта */}
+    <div className="flex items-end gap-3">
+      <div className="flex-1">
+        <input
+          type="text"
+          value={nameInput}
+          onChange={(e) => setNameInput(e.target.value)}
+          onKeyDown={onNameKeyDown}
+          placeholder="Например: огурец"
+          className="w-full rounded-xl border bg-white px-4 py-3 text-sm text-[#1e1e1e] placeholder:text-[#777]"
+          autoComplete="off"
+        />
       </div>
-
-      <div className="flex gap-2">
-        <button
-          type="button"
-          onClick={handleClearAll}
-          className="rounded-xl border px-4 py-2 text-sm hover:bg-gray-50"
-        >
-          Очистить
-        </button>
-
-      {!hideAction && (
       <button
         type="button"
-        onClick={handleGenerate}
-        disabled={items.length === 0 || submitting}
-        className="w-full rounded-xl bg-black text-white py-3.5 font-medium shadow-sm hover:bg-gray-900 active:scale-[0.99] focus:outline-none focus:ring-2 focus:ring-black/30 transition disabled:opacity-40 disabled:cursor-not-allowed"
-        aria-busy={submitting}
+        onClick={handleAdd}
+        disabled={!nameInput.trim()}
+        className="btn-soft shrink-0 whitespace-nowrap rounded-2xl px-6 py-3 text-[15px] font-semibold text-gray-900 disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        <span className="inline-flex items-center gap-2">
+          <span className="text-xl leading-none">+</span> Добавить
+        </span>
+      </button>
+    </div>
+
+    {/* Кнопки действий */}
+    <div className="flex gap-3">
+      <button
+        type="button"
+        onClick={handleClearAll}
+        className="btn-soft rounded-2xl px-6 py-3 text-[15px] font-semibold text-gray-900"
+      >
+        <span className="inline-flex items-center gap-2">
+          <span className="text-base leading-none">✕</span> Очистить
+        </span>
+      </button>
+
+      {!hideAction && (
+        <button
+          type="button"
+          onClick={handleGenerate}
+          disabled={items.length === 0 || submitting}
+          className="btn-peach w-full rounded-[28px] px-6 py-3.5 font-semibold text-white focus:outline-none focus:ring-2 focus:ring-white/30 transition disabled:opacity-40 disabled:cursor-not-allowed"
+          aria-busy={submitting}
         >
-        {submitting ? "Генерируем рецепты…" : "Показать рецепты"}
+          {submitting ? "Генерируем рецепты…" : "Показать рецепты"}
         </button>
       )}
+    </div>
+  </section>
+);
 
-      </div>
-    </section>
-  );
 }

--- a/src/components/recipe-card.tsx
+++ b/src/components/recipe-card.tsx
@@ -1,12 +1,18 @@
 // src/components/recipe-card.tsx
 "use client";
+
 import { useMemo, useState } from "react";
 import type { RecipeDto, IngredientDto, StepDto } from "@/types/recipe";
 
-export default function RecipeCard({ recipe }: { recipe: RecipeDto & { lead?: string } }) {
+export default function RecipeCard({
+  recipe,
+}: {
+  recipe: RecipeDto & { lead?: string };
+}) {
   const [open, setOpen] = useState(false);
 
-  const isFast = typeof recipe.time_min === "number" && recipe.time_min <= 10;
+  const isFast =
+    typeof recipe.time_min === "number" && recipe.time_min <= 10;
 
   const usedProducts = useMemo(() => {
     const uniq = Array.from(
@@ -16,16 +22,20 @@ export default function RecipeCard({ recipe }: { recipe: RecipeDto & { lead?: st
           .filter(Boolean)
       )
     );
-    return uniq.slice(0, 6); // компактный список
+    return uniq.slice(0, 6);
   }, [recipe.ingredients]);
 
   const copyRecipe = () => {
     const text = [
-      `${recipe.title} (${recipe.portion ?? "1 порция"}, ~${recipe.time_min ?? 15} мин)\n`,
+      `${recipe.title} (${recipe.portion ?? "1 порция"}, ~${
+        recipe.time_min ?? 15
+      } мин)\n`,
       "🧾 Ингредиенты:",
       ...recipe.ingredients.map(
         (i: IngredientDto) =>
-          `- ${i.name} — ${i.amount ?? ""} ${i.unit ?? ""}${i.note ? ` (${i.note})` : ""}`
+          `- ${i.name} — ${i.amount ?? ""} ${i.unit ?? ""}${
+            i.note ? ` (${i.note})` : ""
+          }`
       ),
       "\n🧭 Шаги:",
       ...recipe.steps.map(
@@ -40,14 +50,12 @@ export default function RecipeCard({ recipe }: { recipe: RecipeDto & { lead?: st
   };
 
   return (
-    <div className="p-4 rounded-2xl shadow bg-white space-y-2">
-      {/* Заголовок + время/порции + копирование */}
-      <div className="flex justify-between items-start gap-3">
+    <article className="rounded-3xl border border-gray-200 bg-white/90 shadow-sm p-4 sm:p-5">
+      {/* Заголовок + мета + копирование */}
+      <header className="flex justify-between items-start gap-3">
         <div className="min-w-0">
-          <h3 className="text-lg font-semibold flex items-center gap-2">
+          <h3 className="text-lg sm:text-xl font-semibold text-[#1e1e1e] flex items-center gap-2">
             <span className="truncate">{recipe.title}</span>
-
-            {/* Бейдж "быстро" для рецептов ≤ 10 мин */}
             {isFast && (
               <span
                 className="inline-flex items-center rounded-full border border-green-500 text-green-600 px-2 py-0.5 text-xs whitespace-nowrap"
@@ -58,38 +66,40 @@ export default function RecipeCard({ recipe }: { recipe: RecipeDto & { lead?: st
             )}
           </h3>
 
-          <div className="text-sm text-gray-500 mt-1">
+          <p className="mt-1 text-xs sm:text-sm text-gray-500">
             ⏱ ~{recipe.time_min ?? 15} мин • {recipe.portion ?? "1 порция"}
-          </div>
+          </p>
         </div>
 
         <button
           onClick={copyRecipe}
-          className="text-sm text-blue-600 hover:underline shrink-0"
+          className="btn-soft rounded-2xl px-3 py-1.5 text-[13px] font-semibold text-gray-900 shrink-0"
           title="Скопировать рецепт"
           aria-label="Скопировать рецепт"
         >
-          📋
+          📋 Копировать
         </button>
-      </div>
+      </header>
 
-      {/* lead — вводный абзац */}
+      {/* Лид/подзаголовок */}
       {"lead" in recipe && recipe.lead && (
-        <p className="text-sm text-muted-foreground">{recipe.lead}</p>
+        <p className="mt-2 text-sm text-gray-600">{recipe.lead}</p>
       )}
 
-      {/* Короткий список использованных продуктов */}
+      {/* Используемые продукты */}
       {usedProducts.length > 0 && (
-        <p className="text-sm text-gray-600">
+        <p className="mt-2 text-sm text-gray-600">
           <span className="font-medium">Используются:</span>{" "}
           {usedProducts.join(", ")}
         </p>
       )}
 
       {/* Ингредиенты */}
-      <div className="mt-1">
-        <p className="font-medium">Ингредиенты:</p>
-        <ul className="list-disc list-inside text-sm text-gray-700">
+      <section className="mt-3">
+        <h4 className="text-sm font-semibold text-[#1e1e1e]">
+          Ингредиенты
+        </h4>
+        <ul className="mt-1 list-disc list-inside text-sm text-gray-700 space-y-0.5">
           {recipe.ingredients.map((i: IngredientDto, idx) => (
             <li key={idx}>
               {i.name}
@@ -99,30 +109,34 @@ export default function RecipeCard({ recipe }: { recipe: RecipeDto & { lead?: st
             </li>
           ))}
         </ul>
-      </div>
-
-      {/* Кнопка раскрытия шагов */}
-      <button
-        onClick={() => setOpen(!open)}
-        className="mt-3 bg-gray-900 text-white text-sm px-3 py-1.5 rounded-md"
-      >
-        {open ? "Скрыть шаги" : "Показать шаги"}
-      </button>
+      </section>
 
       {/* Шаги */}
-      {open && (
-        <ol className="list-decimal list-inside text-sm space-y-1 mt-2">
-          {recipe.steps.map((s: StepDto) => (
-            <li key={s.order}>
-              <strong>{s.action}</strong>
-              {s.detail && ` — ${s.detail}`}
-              {s.duration_min && (
-                <span className="text-gray-500"> (~{s.duration_min} мин)</span>
-              )}
-            </li>
-          ))}
-        </ol>
-      )}
-    </div>
+      <section className="mt-3">
+        <button
+          onClick={() => setOpen((v) => !v)}
+          className="btn-soft w-full rounded-2xl px-4 py-2 text-[15px] font-semibold text-gray-900"
+        >
+          {open ? "Скрыть шаги" : "Показать шаги"}
+        </button>
+
+        {open && (
+          <ol className="mt-2 list-decimal list-inside text-sm space-y-1">
+            {recipe.steps.map((s: StepDto) => (
+              <li key={s.order}>
+                <strong>{s.action}</strong>
+                {s.detail && ` — ${s.detail}`}
+                {s.duration_min && (
+                  <span className="text-gray-500">
+                    {" "}
+                    (~{s.duration_min} мин)
+                  </span>
+                )}
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
+    </article>
   );
 }

--- a/src/components/streamed-recipes-demo.tsx
+++ b/src/components/streamed-recipes-demo.tsx
@@ -4,9 +4,12 @@
 import { useEffect, useMemo, useRef } from "react";
 import { useStreamedRecipe } from "@/lib/useStreamedRecipe";
 
-type Props = { products: string[] };
+type Props = {
+  products: string[];
+  hideTitle?: boolean; // можно передать, чтобы скрыть внутренний заголовок
+};
 
-export default function StreamedRecipesDemo({ products }: Props) {
+export default function StreamedRecipesDemo({ products, hideTitle = false }: Props) {
   const p = useMemo(
     () => products.map((s) => s.trim()).filter(Boolean),
     [products]
@@ -23,16 +26,18 @@ export default function StreamedRecipesDemo({ products }: Props) {
     if (p.length === 0) return;
     startedRef.current = true;
 
-    // 1️⃣ Базовый — повседневное блюдо
     a.start({ products: p, variant: "basic" });
-
-    // 2️⃣ Что-то интересное — необычная техника/идея
     b.start({ products: p, variant: "creative" });
   }, [p, a, b]);
 
   return (
     <div className="space-y-8">
-      <h2 className="text-lg font-semibold">Ваши рецепты</h2>
+      {/* внутренний заголовок показываем только если НЕ пришёл hideTitle */}
+      {!hideTitle && (
+        <h2 className="whitespace-nowrap text-[20px] sm:text-2xl font-extrabold tracking-tight text-[#1e1e1e] leading-tight mb-2">
+          Ваши рецепты
+        </h2>
+      )}
 
       <RecipeStreamCard
         title="Базовый рецепт"
@@ -51,24 +56,23 @@ export default function StreamedRecipesDemo({ products }: Props) {
       />
 
       <div className="pt-4 border-t border-border">
-        <button
-          className="rounded-2xl border border-border bg-background px-4 py-2 text-sm hover:bg-gray-50 disabled:opacity-60"
-          disabled={c.isRunning}
-          onClick={() => c.start({ products: p, variant: "upgrade" })}
-        >
-          {c.isRunning ? "Генерируем 3-й…" : "Хочу ещё (вкусный апгрейд)"}
-        </button>
-
-        {c.text && (
-          <div className="mt-6">
-            <RecipeStreamCard
-              title="Вкусный апгрейд"
-              subtitle="То же самое, но вкуснее: добавь до 3 продуктов"
-              text={c.text}
-              running={c.isRunning}
-              error={c.error}
-            />
-          </div>
+        {(c.isRunning || c.text) ? (
+          // Сразу показываем карточку на месте кнопки
+          <RecipeStreamCard
+            title="Вкусный апгрейд"
+            subtitle="То же самое, но вкуснее: добавь до 3 продуктов"
+            text={c.text}
+            running={c.isRunning}
+            error={c.error}
+          />
+        ) : (
+          // До клика — оранжевая CTA
+          <button
+            className="btn-peach w-full sm:w-auto rounded-[28px] px-6 py-4 font-medium text-white focus:outline-none focus:ring-2 focus:ring-white/30 disabled:opacity-60 disabled:cursor-not-allowed"
+            onClick={() => c.start({ products: p, variant: "upgrade" })}
+          >
+            Хочу ещё (вкусный апгрейд)
+          </button>
         )}
       </div>
     </div>
@@ -96,9 +100,7 @@ function RecipeStreamCard({
   return (
     <div className="rounded-2xl border border-border bg-background p-5 text-base leading-relaxed text-foreground shadow-sm">
       <div className="font-semibold text-lg">{firstLine?.trim() || title}</div>
-      {subtitle && (
-        <div className="text-sm text-gray-500 mb-2">{subtitle}</div>
-      )}
+      {subtitle && <div className="text-sm text-gray-500 mb-2">{subtitle}</div>}
 
       <p className="whitespace-pre-wrap text-sm leading-6 mt-1">
         {body || (running ? "…" : "—")}

--- a/src/components/ui/upload-zone.tsx
+++ b/src/components/ui/upload-zone.tsx
@@ -128,36 +128,53 @@ export default function UploadZone({
           ].join(" ")}
         >
           {!preview ? (
-            <>
-              {!compact && (
-                <>
-                  {/* Камера с ореолом и пульсацией */}
-                  <div className="camera-wrap mb-5 flex items-center justify-center">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      className="h-12 w-12 camera-icon"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth={1.7}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M3 7h3l1.5-2h9L18 7h3a1 1 0 011 1v11a1 1 0 01-1 1H3a1 1 0 01-1-1V8a1 1 0 011-1zm9 3a4 4 0 100 8 4 4 0 000-8z"
-                      />
-                    </svg>
-                  </div>
+            // ----------- НОВАЯ ЛОГИКА -----------
+            compact ? (
+              // компактный режим: только маленькая иконка камеры
+              <div className="flex items-center justify-center py-2">
+  <div className="flex h-16 w-16 items-center justify-center rounded-full border border-gray-300 bg-white/90 shadow-sm">
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className="h-7 w-7 text-gray-700"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.7}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round"
+        d="M3 7h3l1.5-2h9L18 7h3a1 1 0 011 1v11a1 1 0 01-1 1H3a1 1 0 01-1-1V8a1 1 0 011-1zm9 3a4 4 0 100 8 4 4 0 000-8z" />
+    </svg>
+  </div>
+</div>
 
-                  <div className="text-1xl font-extrabold tracking-tight text-[#1e1e1e]">
-                    Нажми, чтобы сфоткать продукты
-                  </div>
-                  <div className="mt-0 text-sm text-gray-600">
-                    Покажи что у тебя есть
-                  </div>
-                </>
-              )}
-            </>
+            ) : (
+              // полноразмерный режим: большая иконка + тексты
+              <>
+                <div className="camera-wrap mb-5 flex items-center justify-center">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="h-12 w-12 camera-icon"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={1.7}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M3 7h3l1.5-2h9L18 7h3a1 1 0 011 1v11a1 1 0 01-1 1H3a1 1 0 01-1-1V8a1 1 0 011-1zm9 3a4 4 0 100 8 4 4 0 000-8z"
+                    />
+                  </svg>
+                </div>
+                <div className="text-1xl font-extrabold tracking-tight text-[#1e1e1e]">
+                  Нажми, чтобы сфоткать продукты
+                </div>
+                <div className="mt-0 text-sm text-gray-600">
+                  Покажи что у тебя есть
+                </div>
+              </>
+            )
+            // ------------------------------------
           ) : (
             <div className="w-full">
               {/* eslint-disable-next-line @next/next/no-img-element */}

--- a/src/components/ui/upload-zone.tsx
+++ b/src/components/ui/upload-zone.tsx
@@ -34,7 +34,7 @@ export default function UploadZone({
         });
       } catch {}
 
-      // читаем превью
+      // превью
       const dataUrl = await new Promise<string>((resolve, reject) => {
         const reader = new FileReader();
         reader.onload = () => resolve(String(reader.result));
@@ -54,22 +54,13 @@ export default function UploadZone({
         });
         const data = await res.json();
 
-        const rawProducts: string[] = Array.isArray(data?.products)
-          ? data.products
-          : [];
+        const raw: string[] = Array.isArray(data?.products) ? data.products : [];
         const products = Array.from(
-          new Set(
-            rawProducts
-              .map((x) => String(x).trim().toLowerCase())
-              .filter(Boolean)
-          )
+          new Set(raw.map((x) => String(x).trim().toLowerCase()).filter(Boolean))
         );
 
-        if (products.length) {
-          onRecognized(products, dataUrl);
-        } else {
-          alert("Не удалось распознать продукты. Добавь вручную или выбери другое фото.");
-        }
+        if (products.length) onRecognized(products, dataUrl);
+        else alert("Не удалось распознать продукты. Добавь вручную или выбери другое фото.");
       } catch (err) {
         console.error(err);
         alert("Ошибка при сканировании.");
@@ -93,11 +84,9 @@ export default function UploadZone({
     e.preventDefault();
     setIsOver(true);
   }
-
   function handleDragLeave() {
     setIsOver(false);
   }
-
   async function handleDrop(e: React.DragEvent<HTMLLabelElement>) {
     e.preventDefault();
     setIsOver(false);
@@ -109,15 +98,15 @@ export default function UploadZone({
   return (
     <div
       className={[
-        "rounded-2xl border border-dashed",
+        "glass-card rounded-3xl border",
         "transition-all duration-500 ease-out",
         compact ? "p-3" : "p-0",
       ].join(" ")}
     >
       <label
         className={[
-          "block cursor-pointer transition-all duration-300",
-          isOver ? "outline outline-2 outline-black/40" : "",
+          "block cursor-pointer rounded-3xl transition-all duration-300",
+          isOver ? "outline outline-2 outline-white/60" : "",
         ].join(" ")}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
@@ -131,7 +120,6 @@ export default function UploadZone({
           onChange={handleFileChange}
         />
 
-        {/* Зона клика */}
         <div
           className={[
             "flex flex-col items-center justify-center text-center",
@@ -143,15 +131,15 @@ export default function UploadZone({
             <>
               {!compact && (
                 <>
-                  {/* 📸 Кликабельная иконка фотоаппарата */}
-                  <div className="mb-4 text-gray-400 transition-transform duration-200 hover:scale-110">
+                  {/* Камера с ореолом и пульсацией */}
+                  <div className="camera-wrap mb-5 flex items-center justify-center">
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
-                      className="h-14 w-14"
-                      fill="none"
+                      className="h-12 w-12 camera-icon"
                       viewBox="0 0 24 24"
+                      fill="none"
                       stroke="currentColor"
-                      strokeWidth={1.5}
+                      strokeWidth={1.7}
                     >
                       <path
                         strokeLinecap="round"
@@ -161,15 +149,12 @@ export default function UploadZone({
                     </svg>
                   </div>
 
-                  <div className="mb-2 text-base font-medium">
+                  <div className="text-1xl font-extrabold tracking-tight text-[#1e1e1e]">
                     Нажми, чтобы сфоткать продукты
                   </div>
-                  <div className="text-xs text-gray-500">
-                      Поставь продукты на стол — я подскажу,<br />
-                      что приготовить
+                  <div className="mt-0 text-sm text-gray-600">
+                    Покажи что у тебя есть
                   </div>
-
-                  {/* Кнопку убрали, иконка — теперь главный CTA */}
                 </>
               )}
             </>
@@ -180,12 +165,13 @@ export default function UploadZone({
                 src={preview}
                 alt="preview"
                 className={[
-                  "mx-auto w-auto rounded-xl object-contain transition-all duration-500 ease-out",
+                  "mx-auto w-auto rounded-xl object-contain",
+                  "transition-all duration-500 ease-out",
                   compact ? "h-28" : "max-h-64",
                 ].join(" ")}
               />
               {loading && (
-                <div className="mt-2 text-xs text-gray-500">
+                <div className="mt-2 text-xs text-gray-600">
                   Распознаём продукты…
                 </div>
               )}

--- a/tree.txt
+++ b/tree.txt
@@ -1,28 +1,323 @@
 .
-.vercel
-.vercel/project.json
-.vercel/README.txt
-.env.local
-postcss.config.mjs
-next.config.js
-next-env.d.ts
-README.md
-public
-public/file.svg
-public/vercel.svg
-public/next.svg
-public/globe.svg
-public/assets
-public/window.svg
-package-lock.json
-package.json
-components.json
-tsconfig.json
-tree.txt
-eslint.config.mjs
-next.config.ts
-src
-src/types
-src/app
-src/components
-src/lib
+├── components.json
+├── eslint.config.mjs
+├── next-env.d.ts
+├── next.config.js
+├── next.config.ts
+├── node_modules
+│   ├── @alloc
+│   ├── @emnapi
+│   ├── @eslint
+│   ├── @eslint-community
+│   ├── @humanfs
+│   ├── @humanwhocodes
+│   ├── @img
+│   ├── @isaacs
+│   ├── @jridgewell
+│   ├── @napi-rs
+│   ├── @next
+│   ├── @nodelib
+│   ├── @nolyfill
+│   ├── @radix-ui
+│   ├── @rtsao
+│   ├── @rushstack
+│   ├── @supabase
+│   ├── @swc
+│   ├── @tailwindcss
+│   ├── @tybys
+│   ├── @types
+│   ├── @typescript-eslint
+│   ├── @unrs
+│   ├── @upstash
+│   ├── acorn
+│   ├── acorn-jsx
+│   ├── ajv
+│   ├── ansi-styles
+│   ├── argparse
+│   ├── aria-query
+│   ├── array-buffer-byte-length
+│   ├── array-includes
+│   ├── array.prototype.findlast
+│   ├── array.prototype.findlastindex
+│   ├── array.prototype.flat
+│   ├── array.prototype.flatmap
+│   ├── array.prototype.tosorted
+│   ├── arraybuffer.prototype.slice
+│   ├── ast-types-flow
+│   ├── async-function
+│   ├── available-typed-arrays
+│   ├── axe-core
+│   ├── axobject-query
+│   ├── balanced-match
+│   ├── brace-expansion
+│   ├── braces
+│   ├── call-bind
+│   ├── call-bind-apply-helpers
+│   ├── call-bound
+│   ├── callsites
+│   ├── caniuse-lite
+│   ├── chalk
+│   ├── chownr
+│   ├── class-variance-authority
+│   ├── client-only
+│   ├── clsx
+│   ├── color-convert
+│   ├── color-name
+│   ├── concat-map
+│   ├── cross-spawn
+│   ├── csstype
+│   ├── damerau-levenshtein
+│   ├── data-view-buffer
+│   ├── data-view-byte-length
+│   ├── data-view-byte-offset
+│   ├── debug
+│   ├── deep-is
+│   ├── define-data-property
+│   ├── define-properties
+│   ├── detect-libc
+│   ├── doctrine
+│   ├── dunder-proto
+│   ├── emoji-regex
+│   ├── enhanced-resolve
+│   ├── es-abstract
+│   ├── es-define-property
+│   ├── es-errors
+│   ├── es-iterator-helpers
+│   ├── es-object-atoms
+│   ├── es-set-tostringtag
+│   ├── es-shim-unscopables
+│   ├── es-to-primitive
+│   ├── escape-string-regexp
+│   ├── eslint
+│   ├── eslint-config-next
+│   ├── eslint-import-resolver-node
+│   ├── eslint-import-resolver-typescript
+│   ├── eslint-module-utils
+│   ├── eslint-plugin-import
+│   ├── eslint-plugin-jsx-a11y
+│   ├── eslint-plugin-react
+│   ├── eslint-plugin-react-hooks
+│   ├── eslint-scope
+│   ├── eslint-visitor-keys
+│   ├── espree
+│   ├── esquery
+│   ├── esrecurse
+│   ├── estraverse
+│   ├── esutils
+│   ├── fast-deep-equal
+│   ├── fast-glob
+│   ├── fast-json-stable-stringify
+│   ├── fast-levenshtein
+│   ├── fastq
+│   ├── file-entry-cache
+│   ├── fill-range
+│   ├── find-up
+│   ├── flat-cache
+│   ├── flatted
+│   ├── for-each
+│   ├── function-bind
+│   ├── function.prototype.name
+│   ├── functions-have-names
+│   ├── generator-function
+│   ├── get-intrinsic
+│   ├── get-proto
+│   ├── get-symbol-description
+│   ├── get-tsconfig
+│   ├── glob-parent
+│   ├── globals
+│   ├── globalthis
+│   ├── gopd
+│   ├── graceful-fs
+│   ├── graphemer
+│   ├── has-bigints
+│   ├── has-flag
+│   ├── has-property-descriptors
+│   ├── has-proto
+│   ├── has-symbols
+│   ├── has-tostringtag
+│   ├── hasown
+│   ├── ignore
+│   ├── import-fresh
+│   ├── imurmurhash
+│   ├── internal-slot
+│   ├── is-array-buffer
+│   ├── is-async-function
+│   ├── is-bigint
+│   ├── is-boolean-object
+│   ├── is-bun-module
+│   ├── is-callable
+│   ├── is-core-module
+│   ├── is-data-view
+│   ├── is-date-object
+│   ├── is-extglob
+│   ├── is-finalizationregistry
+│   ├── is-generator-function
+│   ├── is-glob
+│   ├── is-map
+│   ├── is-negative-zero
+│   ├── is-number
+│   ├── is-number-object
+│   ├── is-regex
+│   ├── is-set
+│   ├── is-shared-array-buffer
+│   ├── is-string
+│   ├── is-symbol
+│   ├── is-typed-array
+│   ├── is-weakmap
+│   ├── is-weakref
+│   ├── is-weakset
+│   ├── isarray
+│   ├── isexe
+│   ├── iterator.prototype
+│   ├── jiti
+│   ├── js-tokens
+│   ├── js-yaml
+│   ├── json-buffer
+│   ├── json-schema-traverse
+│   ├── json-stable-stringify-without-jsonify
+│   ├── json5
+│   ├── jsx-ast-utils
+│   ├── keyv
+│   ├── language-subtag-registry
+│   ├── language-tags
+│   ├── levn
+│   ├── lightningcss
+│   ├── lightningcss-darwin-arm64
+│   ├── locate-path
+│   ├── lodash.merge
+│   ├── loose-envify
+│   ├── lucide-react
+│   ├── magic-string
+│   ├── math-intrinsics
+│   ├── merge2
+│   ├── micromatch
+│   ├── minimatch
+│   ├── minimist
+│   ├── minipass
+│   ├── minizlib
+│   ├── ms
+│   ├── nanoid
+│   ├── napi-postinstall
+│   ├── natural-compare
+│   ├── next
+│   ├── object-assign
+│   ├── object-inspect
+│   ├── object-keys
+│   ├── object.assign
+│   ├── object.entries
+│   ├── object.fromentries
+│   ├── object.groupby
+│   ├── object.values
+│   ├── openai
+│   ├── optionator
+│   ├── own-keys
+│   ├── p-limit
+│   ├── p-locate
+│   ├── parent-module
+│   ├── path-exists
+│   ├── path-key
+│   ├── path-parse
+│   ├── picocolors
+│   ├── picomatch
+│   ├── possible-typed-array-names
+│   ├── postcss
+│   ├── prelude-ls
+│   ├── prop-types
+│   ├── punycode
+│   ├── queue-microtask
+│   ├── react
+│   ├── react-dom
+│   ├── react-is
+│   ├── reflect.getprototypeof
+│   ├── regexp.prototype.flags
+│   ├── resolve
+│   ├── resolve-from
+│   ├── resolve-pkg-maps
+│   ├── reusify
+│   ├── run-parallel
+│   ├── safe-array-concat
+│   ├── safe-push-apply
+│   ├── safe-regex-test
+│   ├── scheduler
+│   ├── semver
+│   ├── set-function-length
+│   ├── set-function-name
+│   ├── set-proto
+│   ├── sharp
+│   ├── shebang-command
+│   ├── shebang-regex
+│   ├── side-channel
+│   ├── side-channel-list
+│   ├── side-channel-map
+│   ├── side-channel-weakmap
+│   ├── source-map-js
+│   ├── stable-hash
+│   ├── stop-iteration-iterator
+│   ├── string.prototype.includes
+│   ├── string.prototype.matchall
+│   ├── string.prototype.repeat
+│   ├── string.prototype.trim
+│   ├── string.prototype.trimend
+│   ├── string.prototype.trimstart
+│   ├── strip-bom
+│   ├── strip-json-comments
+│   ├── styled-jsx
+│   ├── supports-color
+│   ├── supports-preserve-symlinks-flag
+│   ├── tailwind-merge
+│   ├── tailwindcss
+│   ├── tapable
+│   ├── tar
+│   ├── tinyglobby
+│   ├── to-regex-range
+│   ├── tr46
+│   ├── ts-api-utils
+│   ├── tsconfig-paths
+│   ├── tslib
+│   ├── tw-animate-css
+│   ├── type-check
+│   ├── typed-array-buffer
+│   ├── typed-array-byte-length
+│   ├── typed-array-byte-offset
+│   ├── typed-array-length
+│   ├── typescript
+│   ├── unbox-primitive
+│   ├── uncrypto
+│   ├── undici-types
+│   ├── unrs-resolver
+│   ├── uri-js
+│   ├── webidl-conversions
+│   ├── whatwg-url
+│   ├── which
+│   ├── which-boxed-primitive
+│   ├── which-builtin-type
+│   ├── which-collection
+│   ├── which-typed-array
+│   ├── word-wrap
+│   ├── ws
+│   ├── yallist
+│   ├── yocto-queue
+│   └── zod
+├── package-lock.json
+├── package.json
+├── postcss.config.mjs
+├── project_tree_full.txt
+├── public
+│   ├── file.svg
+│   ├── globe.svg
+│   ├── next.svg
+│   ├── robots.txt
+│   ├── vercel.svg
+│   └── window.svg
+├── README.md
+├── src
+│   ├── _middleware.ts
+│   ├── app
+│   ├── components
+│   ├── lib
+│   ├── middleware.ts
+│   └── types
+├── tree.txt
+└── tsconfig.json
+
+301 directories, 20 files


### PR DESCRIPTION
Привёл страницу рецептов к стилю главной: стеклянные карточки, типографика, отступы.

Улучшил UX потока:

Кнопка «Хочу ещё (вкусный апгрейд)» → после клика сразу исчезает, на её месте появляется карточка 3-го рецепта и начинает печататься текст.

Оранжевая кнопка в стиле btn-peach (как «Показать рецепт»).

Внутренний заголовок «Ваши рецепты» теперь можно скрывать пропом hideTitle (используется на /recipes, чтобы не было дубля заголовков).

Мобильные правки: ровные отступы, корректная ширина карточек, центровка триггера «количество».